### PR TITLE
feat: start implementing Godot and Python bridge

### DIFF
--- a/project/pybridge.gd
+++ b/project/pybridge.gd
@@ -3,6 +3,48 @@ extends Node
 var DIR = OS.get_executable_path().get_base_dir()
 var BIN_PATH = DIR.plus_file("bin/main/main")
 
+const UDP_IP := "127.0.0.1"
+const UDP_PORT := 50505
+
+var server := UDPServer.new()
+var process_pids := []
+
 func _ready():
 	# Run the process in the background, while the game is running
 	OS.create_process(BIN_PATH, [])
+	server_start()
+
+
+func _process(_delta):
+	server.poll()
+	if server.is_connection_available():
+		var peer := server.take_connection()
+		var packet = peer.get_packet().get_string_from_utf8()
+		var json = JSON.new()
+		json.parse(packet)
+		packet = json.data
+
+		if packet is Array:
+			var type = packet.pop_front()
+			match type:
+				"PIDs":
+					process_pids.append_array(packet)
+				"KEY_INPUT":
+					print(packet)
+					# TODO: Implement functions to handle game inputs
+		else:
+			push_error("Invalid type received!")
+
+func server_start():
+	server.listen(UDP_PORT)
+	set_process(true)
+
+
+func server_stop():
+	server.stop()
+	set_process(false)
+
+
+func kill_processes():
+	for pid in process_pids:
+		OS.kill(pid)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ mediapipe==0.9.1.0
 numpy==1.24.4
 opencv-contrib-python==4.9.0.80
 pyautogui==0.9.54
+keyboard==0.13.5
+pyinstaller==6.4.0

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,41 @@
+import keyboard
+import json
+import os
+import socket
+
+UDP_IP = "127.0.0.1"
+UDP_PORT = 50505
+
+key_inputs = [
+    "w",
+    "a",
+    "s",
+    "d",
+]
+
+
+class SocketConn:
+    def __init__(self, sock) -> None:
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+    def put_packet(self, packet):
+        msg_bytes = bytes(json.dumps(packet), "utf-8")
+        self.sock.sendto(msg_bytes, (UDP_IP, UDP_PORT))
+
+    def on_input(self, key_input):
+        key_input = ["KEY_INPUT", key_input]
+        self.put_packet(key_input)
+
+
 def main():
-    print("Hello world")
+    conn = SocketConn()
+    pid = os.getppid()
+    conn.put_packet(["PIDs", pid])
+
+    for key in key_inputs:
+        keyboard.add_hotkey(key, lambda: conn.on_input(key))
+
+    keyboard.wait()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Start implementing the logic that will enable the Python code to communicate with Godot.

On the Python side, the respective key inputs must be mapped appropriately and sent via the network. On the Godot side, functions must be implemented that takes the associated key input and transforms it into appropriate movements and actions.